### PR TITLE
Support Nested Fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,13 @@ export declare function ModelProperty(jsonField?: string, type?: any, required?:
  */
 export declare class BaseModel {
     /**
+     * Find value based on json field key
+     * @param options
+     * @param {string} jsonField - name of the field in JSON
+     * @returns {object}
+     */
+    private findValue (options: any, jsonField: string)
+    /**
      * Deserialize value depending on its type
      * @param value - value to deserialize
      * @param targetClass - class to cast value to (if needed)

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ var Helpers = /** @class */ (function () {
      * Regular expression used to check the json field is a nested field.
      * @type {RegExp}
      */
-    Helpers.NESTED_JSON_KEY_REGEXP = /[a-z0-9-_]+/g;
+    Helpers.NESTED_JSON_KEY_REGEXP = /[A-Za-z0-9_]+/g;
     return Helpers;
 }());
 /**

--- a/index.js
+++ b/index.js
@@ -40,6 +40,14 @@ var Helpers = /** @class */ (function () {
         return Helpers.DATE_STRING_REGEXP.test(value);
     };
     /**
+     * Check if passed value is a nested json field
+     * @param {string} value
+     * @returns {RegExpMatchArray | null}
+     */
+    Helpers.getNestedFields = function (value) {
+        return value.match(Helpers.NESTED_JSON_KEY_REGEXP)
+    }
+    /**
      * Regular expression used to check the string is a correct date string according to ISO 8601.
      * Taken from https://stackoverflow.com/a/3143231/6794376
      * We know, that using libraries like moment would be more reliable approach
@@ -49,6 +57,12 @@ var Helpers = /** @class */ (function () {
      * @type {RegExp}
      */
     Helpers.DATE_STRING_REGEXP = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/;
+
+    /**
+     * Regular expression used to check the json field is a nested field.
+     * @type {RegExp}
+     */
+    Helpers.NESTED_JSON_KEY_REGEXP = /[a-z0-9-_]+/g;
     return Helpers;
 }());
 /**
@@ -76,7 +90,7 @@ var Constants = /** @class */ (function () {
  * @param {boolean} required - to force parse value, or will throw an exception
  * @returns {Function}
  */
-function ModelProperty(jsonField, type, required) {
+function ModelProperty(jsonField = "", type, required = true) {
     return function (target, propertyKey, index) {
         // getting name of meta-field
         var key = Constants.CORRESPONDENCES_META_KEY;
@@ -112,8 +126,30 @@ var BaseModel = /** @class */ (function () {
             var correspondence = correspondences_1[_i];
             // if 'jsonField' was not specified, property name stays the same
             var dataField = correspondence.jsonField || correspondence.modelField;
-            this[correspondence.modelField] = this.deserializeValue(options[dataField], correspondence.type, correspondence.key, correspondence.jsonField, correspondence.required);
+            this[correspondence.modelField] = this.deserializeValue(this.findValue(options, dataField), correspondence.type, correspondence.key, correspondence.jsonField, correspondence.required);
         }
+    }
+    /**
+     * Find value based on json field key
+     * @param options
+     * @param {string} jsonField - name of the field in JSON
+     * @returns {object}
+     */
+    BaseModel.prototype.findValue = function (options, jsonField) {
+        // init an empty value
+        var value = undefined
+        // get nested fields from jsonField
+        var nestedFields = Helpers.getNestedFields(jsonField)
+        // check if jsonField has nested fields
+        if(nestedFields){
+            // loop through nested fields 
+            nestedFields.forEach(field => {
+                value = value ? value[field] : options[field]
+            });
+        }else{
+            value = options[jsonField]
+        }
+        return value
     }
     /**
      * Deserialize value depending on its type

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ class Helpers {
      * Regular expression used to check the json field is a nested field.
      * @type {RegExp}
      */
-    private static readonly NESTED_JSON_KEY_REGEXP = /[a-z0-9-_]+/g;
+    private static readonly NESTED_JSON_KEY_REGEXP = /[A-Za-z0-9_]+/g;
 
     /**
      * Check if passed value is an array

--- a/readme.md
+++ b/readme.md
@@ -35,8 +35,11 @@ npm install --save ts-json-mapper
         @ModelProperty()
         public born: Date;
 
-        @ModelProperty('given_name')
+        @ModelProperty('given_name', String, true)
         public givenName: string;
+        
+        @ModelProperty('apples_in_pockets.0.color', String)
+        public lastAppleInPocketColor: string;
 
         @ModelProperty('favourite_apple', Apple)
         public favouriteApple: Apple;
@@ -49,7 +52,7 @@ npm install --save ts-json-mapper
     Note:
 
     - `ModelProperty` may be used without parameters when field names in JSON and TS model coincide and data is of primary type (`boolean`, `number` or `string`);
-    - `ModelProperty` may be used with a single string parameter which specifies field name in JSON (data from field with that name will be mapped to decorated property);
+    - `ModelProperty` may be used with a single string parameter which specifies field name in JSON (data from field with that name will be mapped to decorated property), field can be nested for objects or array, e.g `apples_in_pockets.0.color`;
     - `ModelProperty` may be used with two parameters: first being name of field in JSON, and second - class, which JSON data will be cast to; for arrays, **do not** use `Class[]`, use just `Class` instead;
     - `ModelProperty` may be used with three parameters: first two are the same as in previous entry, and the third one is `required`: if `required` is set to `true`, and JSON doesn't contain any value in specified field, an error will be thrown.
 
@@ -63,8 +66,9 @@ npm install --save ts-json-mapper
             "color": "red"
         },
         "apples_in_pockets": [
-            { "color": "green" }
-        ]
+            { "color": "green" },
+            { "color": "gingergold" }
+        ],
     };
 
     let person: Person = new Person(data);


### PR DESCRIPTION
Hi @DmitryShashkov ,

I have added support for nested fields that support nested array & object, for example:

JSON
```
{
  "config": {
    "timeout": 30000
  },
  "users": [
    {
      "id": 0,
      "name": "Gorhom"
    },
    {
      "id": 1,
      "name": "Omar"
    }
  ]
}
```

JS
```
class Example extends BaseModel {
    @ModelProperty('config.timeout')
    public timeout: number;

    @ModelProperty('users.0.name')
    public firstUserName: string;
}
```